### PR TITLE
feature/change-repo-name:

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@
 > `Qiita` -> `Zenn`の場合、`paths`には`public/*.md`を設定します。
 
 ```yaml
-name: Run sync-zenn-qiita
+name: Run sync-zenn-qiita-articles
 
 on:
   push:
@@ -218,7 +218,7 @@ on:
 
 ```yaml
 jobs:
-  sync-zenn-qiita:
+  sync-zenn-qiita-articles:
     if: github.actor == '<your-user-name>'
 
     runs-on: ubuntu-latest
@@ -268,13 +268,13 @@ Github Apps トークンの生成を設定します。
           persist-credentials: false
 ```
 
-`sync-zenn-qiita`の実行を設定します。
+`sync-zenn-qiita-articles`の実行を設定します。
 
-`sync-zenn-qiita`の引数は、下表に示します。
+`sync-zenn-qiita-articles`の引数は、下表に示します。
 
 ```yaml
-      - name: Run sync-zenn-qiita
-        uses: r-dev95/sync-zenn-qiita@main
+      - name: Run sync-zenn-qiita-articles
+        uses: r-dev95/sync-zenn-qiita-articles@main
         with:
           zenn-repo-name: <your-zenn-repository-name>
           qiita-repo-name: <your-qiita-repository-name>
@@ -291,7 +291,7 @@ Github Apps トークンの生成を設定します。
 |sync-to-repo-name |〇     |同期先のリポジトリ名           |`Zenn`または`Qiita`用のリポジトリ名                 |
 |git-token         |〇     |同期先への書き込み権限トークン |-                                                   |
 |commit-msg        |-      |同期先へのコミットメッセージ   |デフォルト: `Auto Commit.`                          |
-|config-path       |-      |コンフィグファイルのパス       |デフォルト: `sync-zenn-qiita/dist/sync-config.json` |
+|config-path       |-      |コンフィグファイルのパス       |デフォルト: `sync-zenn-qiita-articles/dist/sync-config.json` |
 
 ### コンフィグファイルを作成
 

--- a/action.yaml
+++ b/action.yaml
@@ -1,4 +1,4 @@
-name: sync zenn qiita
+name: sync zenn qiita articles
 description: |
   Syncs Zenn and Qiita articles mutually.
   Automates article generation and pushing to the repository.
@@ -27,16 +27,16 @@ inputs:
   config-path:
     description: The config path for the Converter.
     required: false
-    default: "sync-zenn-qiita/dist/sync-config.json"
+    default: "sync-zenn-qiita-articles/dist/sync-config.json"
 
 runs:
   using: composite
   steps:
     - name: Setup env variables
       run: |
-        echo "ACTIONS_REPO_NAME=sync-zenn-qiita" >> $GITHUB_ENV
+        echo "ACTIONS_REPO_NAME=sync-zenn-qiita-articles" >> $GITHUB_ENV
         echo "DIFF_FPATH=../diff.txt" >> $GITHUB_ENV
-        echo "CONVERTER_FPATH=sync-zenn-qiita/dist/index.js" >> $GITHUB_ENV
+        echo "CONVERTER_FPATH=sync-zenn-qiita-articles/dist/index.js" >> $GITHUB_ENV
         echo "ZENN_CONTENT_PATH=${{ inputs.zenn-repo-name }}/articles" >> $GITHUB_ENV
         echo "QIITA_CONTENT_PATH=${{ inputs.qiita-repo-name }}/public" >> $GITHUB_ENV
         if [ "${{ inputs.sync-to-repo-name }}" = "${{ inputs.qiita-repo-name }}" ]; then
@@ -58,7 +58,7 @@ runs:
       with:
         node-version: 24
 
-    - name: Checkout repository for sync-zenn-qiita
+    - name: Checkout repository for sync-zenn-qiita-articles
       uses: actions/checkout@v4
       with:
         repository: r-dev95/${{ env.ACTIONS_REPO_NAME }}


### PR DESCRIPTION
- リポジトリ名の変更対応。

変更理由:
- Github Marketplaceに登録後、削除したため、再度同じリポジトリ名、action.yamlのnameを使用できないため。

同様の現象の報告:
- https://github.com/orgs/community/discussions/113415
- https://github.com/orgs/community/discussions/148885